### PR TITLE
Implement localizable desc var for Ghost Print

### DIFF
--- a/Bunco.lua
+++ b/Bunco.lua
@@ -2010,7 +2010,7 @@ function SMODS.INIT.Bunco()
     local joker_ghostprint = SMODS.Joker:new(
         'Ghost Print', -- Name
         'ghostprint', -- Slug
-        {extra = {last_hand = nil or 'Nothing'}}, -- Config
+        {extra = {last_hand = nil}}, -- Config
         {x = 3, y = 1}, -- Sprite position
         loc_ghostprint, -- Localization
         2, -- Rarity
@@ -2026,13 +2026,13 @@ function SMODS.INIT.Bunco()
 
         if SMODS.end_calculate_context(context) then
 
-            if self.ability.extra.last_hand ~= nil and self.ability.extra.last_hand ~= 'Nothing' then
+            if self.ability.extra.last_hand ~= nil then
                 mult = mult + G.GAME.hands[self.ability.extra.last_hand].mult
                 chips = hand_chips + G.GAME.hands[self.ability.extra.last_hand].chips
                 update_hand_text({delay = 0, sound = '', modded = true}, {chips = chips, mult = mult})
                 if not context.blueprint then
 
-                    forced_message(tostring(G.localization.misc['poker_hands'][G.GAME.last_hand_played])..'!', self, G.C.HAND_LEVELS[G.GAME.hands[self.ability.extra.last_hand].level], true)
+                    forced_message(G.localization.misc['poker_hands'][G.GAME.last_hand_played]..'!', self, G.C.HAND_LEVELS[G.GAME.hands[self.ability.extra.last_hand].level], true)
 
                 end
             end
@@ -4173,7 +4173,8 @@ function Card.generate_UIBox_ability_table(self)
         elseif self.ability.name == 'Linocut Joker' then -- Linocut Joker localization (\LINO_LOC)
             -- Hot Dog!
         elseif self.ability.name == 'Ghost Print' then -- Ghost Print Joker localization (\GHOS_LOC)
-            loc_vars = {self.ability.extra.last_hand}
+            local ph_last_played = G.localization.misc['poker_hands'][G.GAME.last_hand_played] or " Nothing"
+            loc_vars = {ph_last_played}
         elseif self.ability.name == 'Loan Shark' then -- Loan Shark Joker localization (\LOAN_LOC)
             -- Scammed!
         elseif self.ability.name == 'Basement Joker' then -- Basement Joker localization (\BASE_LOC)

--- a/Bunco.lua
+++ b/Bunco.lua
@@ -2003,7 +2003,7 @@ function SMODS.INIT.Bunco()
         ['text'] = {
             [1] = 'Grants Chips and Mult',
             [2] = 'from last hand type played',
-            [3] = '{C:inactive}(Last poker hand: #1#)'
+            [3] = '{C:inactive}(Last poker hand: {C:attention}#1#{})'
         }
     }
 
@@ -2032,7 +2032,8 @@ function SMODS.INIT.Bunco()
                 update_hand_text({delay = 0, sound = '', modded = true}, {chips = chips, mult = mult})
                 if not context.blueprint then
 
-                    forced_message(G.localization.misc['poker_hands'][G.GAME.last_hand_played]..'!', self, G.C.HAND_LEVELS[G.GAME.hands[self.ability.extra.last_hand].level], true)
+                    forced_message(G.localization.misc['poker_hands'][self.ability.extra.last_hand]..' !', self, G.C.HAND_LEVELS[G.GAME.hands[self.ability.extra.last_hand].level], true)
+                    forced_message(G.localization.misc['poker_hands'][G.GAME.last_hand_played]..'...', self, G.C.HAND_LEVELS[G.GAME.hands[G.GAME.last_hand_played].level], true)
 
                 end
             end


### PR DESCRIPTION
The latest loc patch was for the joker's pop-up message and new blinds. It's to implement the joker's description. Might be dumb.
- `G.localization.misc['poker_hands'][G.GAME.last_hand_played]` actually returns a string so `tostring` isn't really necessary I guess

For the other commit:
- Gave the hand type in the desc a little highlight
- Fixed it so that the message actually work (as intended?):

It shows correct level color for the hand type pops up. Before this fix the color of last hand type's level was shown, but the name was for THIS hand.

Also I did a change, for example your last hand was High Card and this hand is Pair, the message shows `High Card !` then `Pair...`, meaning that the base mult and chips of your last hand got applied! and your current played hand is pending...

I'm new to all this so feel free to edit or just delete

**EDIT**: Sometimes the fire on the mult and chip box got lit even though the chips' not enough to beat the blind, not sure why yet.