### PR TITLE
Fix Spectrum determination when cards with >1 suit are used

### DIFF
--- a/Bunco.lua
+++ b/Bunco.lua
@@ -5613,28 +5613,25 @@ SMODS.PokerHandPart{ -- Spectrum base (Referenced from SixSuits)
 
         local nonwilds = {}
         for i = 1, #hand do
-            -- wild cards don't have to be counted since they fill up the rest
-            if hand[i].ability.name ~= 'Wild Card' then
-                local cardsuits = {}
-                for _, v in ipairs(SMODS.Suit.obj_buffer) do
-                    -- determine table of suits for each card (for future faster calculations)
-                    if hand[i]:is_suit(v, nil, true) then
-                        table.insert(cardsuits, v)
-                    end
+            local cardsuits = {}
+            for _, v in ipairs(SMODS.Suit.obj_buffer) do
+                -- determine table of suits for each card (for future faster calculations)
+                if hand[i]:is_suit(v, nil, true) then
+                    table.insert(cardsuits, v)
                 end
+            end
 
-                -- if somehow no suits: spectrum is impossible
-                if #cardsuits == 0 then
-                    return {}
-                -- if only 1 suit: can be handled immediately
-                elseif #cardsuits == 1 then
-                    -- if suit is already present, not a spectrum, otherwise remove suit from "already used suits"
-                    if suits[cardsuits[1]] == 0 then return {} end
-                    suits[cardsuits[1]] = 0
-                -- add all cards with 2-4 suits to a table to be looked at
-                elseif #cardsuits < 5 then
-                    table.insert(nonwilds, cardsuits)
-                end
+            -- if somehow no suits: spectrum is impossible
+            if #cardsuits == 0 then
+                return {}
+            -- if only 1 suit: can be handled immediately
+            elseif #cardsuits == 1 then
+                -- if suit is already present, not a spectrum, otherwise remove suit from "already used suits"
+                if suits[cardsuits[1]] == 0 then return {} end
+                suits[cardsuits[1]] = 0
+            -- add all cards with 2-4 suits to a table to be looked at
+            elseif #cardsuits < 5 then
+                table.insert(nonwilds, cardsuits)
             end
         end
 

--- a/Bunco.lua
+++ b/Bunco.lua
@@ -5610,7 +5610,6 @@ SMODS.PokerHandPart{ -- Spectrum base (Referenced from SixSuits)
         -- < 5 hand cant be a spectrum
         if #hand < 5 then return {} end
 
-
         local nonwilds = {}
         for i = 1, #hand do
             local cardsuits = {}


### PR DESCRIPTION
Fixes #82 

This PR changes the Spectrum determination to use a recursive approach when cards with 2-4 suits are used, where combinations of selected suits are tested until either all of them have been checked or a Spectrum is found, with early breaks for when a suit has already been used.

Additionally, consideration of wild-card-ness has been removed entirely, and instead it counts the suits (note that this split in the original code was more of a band-aid to prevent issues like this one to occur on wild cards, too). Any card that somehow has 5 or more suits among it (as such, including wild cards that aren't debuffed) is considered to just be a slot filler, since they'll always have a suit that is not covered by the other 4 cards.

I have tested the following scenarios so far:

* Multiple iterations of added suits via suit seals
* Spectrums involving wild cards
* Debuffed wild cards working as intended

But obviously such testing is never comprehensive, especially any jank suit seal interactions.