### PR TITLE
Fix a crash on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.lovelyignore
+.gitignore

--- a/Bunco.json
+++ b/Bunco.json
@@ -9,6 +9,7 @@
 	"version": "5.1",
 	"conflicts": [
         "Lovely (<<0.7.1)",
-		"Talisman (<=2.0.3)"
+		"Talisman (<=2.0.3)",
+		"Steamodded (<<1.0.0~BETA-0404a)"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 A mod that aims to add more content in a way that'd seamlessly exist within the vanilla Balatro!
+
+(Current commit requires Steamodded **1.0.0~BETA-0404a** at minimum; if you must use older Steamodded please also use [older Bunco](https://github.com/Firch/Bunco/releases/tag/5.1).)

--- a/lovely.toml
+++ b/lovely.toml
@@ -3394,7 +3394,7 @@ payload = '''if not from_debuff then
 [[patches]]
 [patches.pattern]
 target = 'card.lua'
-pattern = "if G.GAME.blind and G.GAME.blind.in_blind then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end"
+pattern = "if G.GAME.blind and G.GAME.blind.in_blind and not self.from_quantum then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end"
 position = 'before'
 match_indent = true
 payload = '''end


### PR DESCRIPTION
SMODS edited `Card:remove_from_deck()` and lovely patches were whiffing, updated accordingly (note: will crash under older smods versions now and putting relevant dependencies/conflicts in the json doesn't actually seem to work)